### PR TITLE
Replace zookeeper library to kazoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@ ZooKeeper Browser - Lite
 
 Required Modules
 ----------------
-* zkpython 
+* kazoo
 * web.py
 
 Installing
 ----------
 
     sudo easy_install web.py
-    Install zkpython from contrib folder of zookeeper distribution.
+    sudo easy_install kazoo
 
 or
 
     sudo aptitude install python-webpy
-    sudo aptitude install python-zookeeper
+    sudo aptitude install python-kazoo
 
 
 Running

--- a/code.py
+++ b/code.py
@@ -9,6 +9,7 @@ render = web.template.render('templates/')
 
 try:
     zkc = ZooKepperConnection(os.environ["ZOOKEEPER"])
+    
 except:
     zkc = ZooKepperConnection("127.0.0.1:2181")
 

--- a/zk.py
+++ b/zk.py
@@ -1,16 +1,17 @@
-import zookeeper
+from kazoo.client import KazooClient
 
 class ZooKepperConnection:
     def __init__(self, host, root = "/"):
-        self.handle = zookeeper.init(host)
+        self.zk = KazooClient(hosts='127.0.0.1:2181')
+        self.zk.start()
         self.root = root
 
     def disconnect(self):
-        zookeeper.close(self.handle)
+        self.zk.stop()
 
     def children(self, path):
         p = self.root + path
-        return zookeeper.get_children(self.handle, p)
+        return self.zk.get_children(p)
 
     def raw_data(self, path):
-        return zookeeper.get(self.handle, self.root + path, None)
+        return self.zk.get(self.root + path)


### PR DESCRIPTION
Kazoo is a Python library designed to make working with Zookeeper a more hassle-free experience that is less prone to errors. It is widespread used and easy to install. When I tried to install zkpython I got strange errors and I think kazoo is 
